### PR TITLE
docs: remove broken docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![GitHub release](https://img.shields.io/github/release/placeos/crystal-client.svg)](https://github.com/placeos/crystal-client/releases)
 [![Build Status](https://travis-ci.com/placeos/crystal-client.svg?branch=master)](https://travis-ci.com/placeos/crystal-client)
-[![Docs](https://img.shields.io/badge/docs-available-brightgreen.svg)](https://placeos.github.io/crystal-client/)
 
 A library for building [crystal](crystal-lang.org/) applications that utilise PlaceOS.
 


### PR DESCRIPTION
Temporarilly hide link from README to remove confusion. See #6.

Plan is to build a GitHub action that handles publishing of these as
part of the docs site. Can re-add badges to this (and other repos) when
this is available.