### PR TITLE
feat: expand controller action coverage, with specs

### DIFF
--- a/spec/placeos/api_wrapper/cluster_spec.cr
+++ b/spec/placeos/api_wrapper/cluster_spec.cr
@@ -1,0 +1,14 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::Cluster do
+    describe "#search" do
+    end
+
+    describe "#fetch" do
+    end
+
+    describe "#destroy" do
+    end
+  end
+end

--- a/spec/placeos/api_wrapper/domains_spec.cr
+++ b/spec/placeos/api_wrapper/domains_spec.cr
@@ -1,0 +1,20 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::Domains do
+    describe "#search" do
+    end
+
+    describe "#fetch" do
+    end
+
+    describe "#destroy" do
+    end
+
+    describe "#create" do
+    end
+
+    describe "#update" do
+    end
+  end
+end

--- a/spec/placeos/api_wrapper/drivers_spec.cr
+++ b/spec/placeos/api_wrapper/drivers_spec.cr
@@ -1,0 +1,26 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::Drivers do
+    describe "#search" do
+    end
+
+    describe "#fetch" do
+    end
+
+    describe "#destroy" do
+    end
+
+    describe "#create" do
+    end
+
+    describe "#update" do
+    end
+
+    describe "#recompile" do
+    end
+
+    describe "#compiled" do
+    end
+  end
+end

--- a/spec/placeos/api_wrapper/metadata_spec.cr
+++ b/spec/placeos/api_wrapper/metadata_spec.cr
@@ -37,7 +37,7 @@ module PlaceOS
     mock_metadata = {} of String => String
     Hash(String, JSON::Any).from_json(metadata_json).each { |key, value| mock_metadata[key] = value.to_json }
 
-    describe "fetch" do
+    describe "#fetch" do
       it "gets metadata for a parent" do
         WebMock
           .stub(:get, DOMAIN + "#{client.base}/zone-oOj2lGgsz")
@@ -54,10 +54,10 @@ module PlaceOS
       end
     end
 
-    pending "children" do
+    pending "#children" do
     end
 
-    it "update" do
+    it "#update" do
       WebMock
         .stub(:put, DOMAIN + "#{client.base}/zone-oOj2lGgsz")
         .with(query: {"name" => "Place1"}, body: mock_metadata["Place1"])
@@ -65,7 +65,7 @@ module PlaceOS
       client.update("zone-oOj2lGgsz", "Place1", {name: "frodo"}, "metadata 1").should eq Client::API::Models::Metadata.from_json(mock_metadata["Place1"])
     end
 
-    it "delete" do
+    it "#destroy" do
       WebMock
         .stub(:delete, DOMAIN + "#{client.base}/zone-oOj2lGgsz")
         .with(query: {"name" => "Place1"})

--- a/spec/placeos/api_wrapper/modules_spec.cr
+++ b/spec/placeos/api_wrapper/modules_spec.cr
@@ -142,5 +142,17 @@ module PlaceOS
         result.as_i.should eq(1)
       end
     end
+
+    describe "ping" do
+    end
+
+    describe "settings" do
+    end
+
+    describe "execute" do
+    end
+
+    describe "load" do
+    end
   end
 end

--- a/spec/placeos/api_wrapper/oauth_applications_spec.cr
+++ b/spec/placeos/api_wrapper/oauth_applications_spec.cr
@@ -1,0 +1,20 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::OAuthApplications do
+    describe "#search" do
+    end
+
+    describe "#fetch" do
+    end
+
+    describe "#destroy" do
+    end
+
+    describe "#create" do
+    end
+
+    describe "#update" do
+    end
+  end
+end

--- a/spec/placeos/api_wrapper/repositories_spec.cr
+++ b/spec/placeos/api_wrapper/repositories_spec.cr
@@ -1,0 +1,38 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::Repositories do
+    describe "#search" do
+    end
+
+    describe "#fetch" do
+    end
+
+    describe "#destroy" do
+    end
+
+    describe "#create" do
+    end
+
+    describe "#update" do
+    end
+
+    describe "#pull" do
+    end
+
+    describe "#loaded_interfaces" do
+    end
+
+    describe "#drivers" do
+    end
+
+    describe "#commits" do
+    end
+
+    describe "#details" do
+    end
+
+    describe "#branches" do
+    end
+  end
+end

--- a/spec/placeos/api_wrapper/root_spec.cr
+++ b/spec/placeos/api_wrapper/root_spec.cr
@@ -1,0 +1,20 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::Root do
+    describe "#singal" do
+    end
+
+    describe "#version" do
+    end
+
+    describe "#root" do
+    end
+
+    describe "#reindex" do
+    end
+
+    describe "#backfill" do
+    end
+  end
+end

--- a/spec/placeos/api_wrapper/settings_spec.cr
+++ b/spec/placeos/api_wrapper/settings_spec.cr
@@ -1,0 +1,23 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::Settings do
+    describe "#search" do
+    end
+
+    describe "#fetch" do
+    end
+
+    describe "#destroy" do
+    end
+
+    describe "#create" do
+    end
+
+    describe "#update" do
+    end
+
+    describe "#history" do
+    end
+  end
+end

--- a/spec/placeos/api_wrapper/system_triggers_spec.cr
+++ b/spec/placeos/api_wrapper/system_triggers_spec.cr
@@ -1,0 +1,20 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::SystemTriggers do
+    describe "#search" do
+    end
+
+    describe "#fetch" do
+    end
+
+    describe "#destroy" do
+    end
+
+    describe "#create" do
+    end
+
+    describe "#update" do
+    end
+  end
+end

--- a/spec/placeos/api_wrapper/systems_spec.cr
+++ b/spec/placeos/api_wrapper/systems_spec.cr
@@ -84,7 +84,7 @@ module PlaceOS
       end
     end
 
-    describe "#delete" do
+    describe "#destroy" do
       it "execs a delete request" do
         WebMock
           .stub(:delete, DOMAIN + "#{client.base}/sys-rJQQlR4Cn7")
@@ -212,6 +212,18 @@ module PlaceOS
         result.size.should eq(1)
         result.first.name.should eq("Room 1")
       end
+    end
+
+    describe "#settings" do
+    end
+
+    describe "#add_module" do
+    end
+
+    describe "#remove_module" do
+    end
+
+    describe "#control" do
     end
   end
 end

--- a/spec/placeos/api_wrapper/triggers_spec.cr
+++ b/spec/placeos/api_wrapper/triggers_spec.cr
@@ -1,0 +1,23 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::Triggers do
+    describe "#search" do
+    end
+
+    describe "#fetch" do
+    end
+
+    describe "#destroy" do
+    end
+
+    describe "#create" do
+    end
+
+    describe "#update" do
+    end
+
+    describe "#instances" do
+    end
+  end
+end

--- a/spec/placeos/api_wrapper/users_spec.cr
+++ b/spec/placeos/api_wrapper/users_spec.cr
@@ -1,0 +1,26 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::Users do
+    describe "#search" do
+    end
+
+    describe "#fetch" do
+    end
+
+    describe "#destroy" do
+    end
+
+    describe "#create" do
+    end
+
+    describe "#update" do
+    end
+
+    describe "#current" do
+    end
+
+    describe "#resource_token" do
+    end
+  end
+end

--- a/spec/placeos/api_wrapper/webhook_spec.cr
+++ b/spec/placeos/api_wrapper/webhook_spec.cr
@@ -1,0 +1,6 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::Webhook do
+  end
+end

--- a/spec/placeos/api_wrapper/zones_spec.cr
+++ b/spec/placeos/api_wrapper/zones_spec.cr
@@ -23,7 +23,7 @@ module PlaceOS
 
     zones = Array(JSON::Any).from_json(zones_json).map &.to_json
 
-    describe "search" do
+    describe "#search" do
       it "enumerates all zones" do
         WebMock
           .stub(:get, DOMAIN + client.base)
@@ -62,7 +62,7 @@ module PlaceOS
       end
     end
 
-    describe "#retrieve" do
+    describe "#fetch" do
       it "inspects a zones metadata" do
         WebMock
           .stub(:get, DOMAIN + "#{client.base}/zone-oOj2lGgsz")
@@ -86,13 +86,19 @@ module PlaceOS
       end
     end
 
-    describe "#delete" do
+    describe "#destroy" do
       it "execs a delete request" do
         WebMock
           .stub(:delete, DOMAIN + "#{client.base}/zone-oOj2lGgsz")
         result = client.destroy "zone-oOj2lGgsz"
         result.should be_nil
       end
+    end
+
+    describe "#execute" do
+    end
+
+    describe "#trigger" do
     end
   end
 end

--- a/src/placeos/api/models/authority.cr
+++ b/src/placeos/api/models/authority.cr
@@ -1,6 +1,8 @@
 require "./response"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/authority.cr
+  #
   # Metadata about the PlaceOS instance connected to.
   #
   # This provides information that may be of relevance for authentication or
@@ -12,11 +14,11 @@ module PlaceOS::Client::API::Models
     # Human readable name
     getter name : String
 
-    # FQDN or IP address this authority serves.
-    getter domain : String
-
     # Authority description (markdown).
     getter description : String?
+
+    # FQDN or IP address this authority serves.
+    getter domain : String
 
     # Path that clients should use for initiating authentication.
     getter login_url : String
@@ -24,9 +26,12 @@ module PlaceOS::Client::API::Models
     # Path that clients should use for revoking authentication.
     getter logout_url : String
 
+    # getter internals : Hash(String, JSON::Any)
+
     # Additional configuration / context for clients.
     getter config : Hash(String, ::JSON::Any)
 
+    # # NOTE : This does not exist in the schema
     # Version of application
     getter version : String
   end

--- a/src/placeos/api/models/driver.cr
+++ b/src/placeos/api/models/driver.cr
@@ -2,6 +2,8 @@ require "./response"
 require "./role"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/driver.cr
+  #
   struct Driver < Response
     include Timestamps
     getter name : String

--- a/src/placeos/api/models/driver.cr
+++ b/src/placeos/api/models/driver.cr
@@ -6,6 +6,8 @@ module PlaceOS::Client::API::Models
   #
   struct Driver < Response
     include Timestamps
+
+    # getter id : String
     getter name : String
     getter description : String
 

--- a/src/placeos/api/models/metadata.cr
+++ b/src/placeos/api/models/metadata.cr
@@ -1,6 +1,8 @@
 require "./response"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/68b6de79003471398c53f363828ba6c1e3efae46/src/placeos-models/metadata.cr
+  #
   struct Metadata < Response
     getter name : String
     getter description : String

--- a/src/placeos/api/models/metadata.cr
+++ b/src/placeos/api/models/metadata.cr
@@ -1,9 +1,10 @@
 require "./response"
 
 module PlaceOS::Client::API::Models
-  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/68b6de79003471398c53f363828ba6c1e3efae46/src/placeos-models/metadata.cr
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/metadata.cr
   #
   struct Metadata < Response
+    # getter id : String
     getter name : String
     getter description : String
     getter details : JSON::Any

--- a/src/placeos/api/models/module.cr
+++ b/src/placeos/api/models/module.cr
@@ -2,6 +2,8 @@ require "./response"
 require "./role"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/module.cr
+  #
   struct Module < Response
     include Timestamps
 
@@ -14,17 +16,19 @@ module PlaceOS::Client::API::Models
     # The system this module is bound to (logic modules only).
     getter control_sytem_id : String?
 
+    # getter edge_id : String # | Nil ?
+
     # IP address or resolvable hostname of the device this module connects to.
     getter ip : String?
+
+    # The TCP or UDP port that the associated device communicates on.
+    # getter port : Int32?
 
     # True if the device communicates securely.
     getter tls : Bool?
 
     # Protocol uses UDP rather that TCP.
     getter udp : Bool?
-
-    # The TCP or UDP port that the associated device communicates on.
-    getter port : Int32?
 
     # If enabled, provides an ephemeral connection that disconnects during idle
     # periods.
@@ -33,12 +37,12 @@ module PlaceOS::Client::API::Models
     # The based URI of the remote service (service modules only).
     getter uri : URI?
 
+    # Driver's default name for the module
+    getter name : String
+
     # The modules class name (Display, Lighting etc) if it should differ from the
     # default defined in the driver.
     getter custom_name : String?
-
-    # Driver's default name for the module
-    getter name : String
 
     # The associated driver type.
     getter role : Role
@@ -48,6 +52,8 @@ module PlaceOS::Client::API::Models
 
     # Module start/stop state.
     getter running : Bool
+
+    # getter notes : String
 
     # If enabled, system metrics ignore connectivity state.
     getter ignore_connected : Bool

--- a/src/placeos/api/models/oauth_application.cr
+++ b/src/placeos/api/models/oauth_application.cr
@@ -1,17 +1,52 @@
 require "./response"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/oauth_authentication.cr
+  #
   struct OAuthApplication < Response
     include Timestamps
+
     getter id : String
+
     getter name : String
-    getter uid : String
-    getter secret : String
-    getter scopes : String
+
+    getter authority_id : String
+
+    getter uid : String # client_id?
+
+    getter secret : String # client_secret?
+
+    # getter info_mappings : Hash(String, String)
+
+    # getter authorize_params : Hash(String, String)
+
+    # getter ensure_matching : Hash(String, Array(String))
+
+    # getter site : String
+
+    # getter authorize_url : String
+
+    # getter token_method : String
+
+    # getter auth_scheme : String
+
+    # getter token_url : String
+
+    getter scopes : String # scope ?
+
+    # NOTE : Field does not exist in schema
     getter owner_id : String
+
+    # NOTE : Field does not exist in schema
     getter redirect_uri : String
+
+    # NOTE : Field does not exist in schema
     getter skip_authorization : Bool
+
+    # NOTE : Field does not exist in schema
     getter confidential : Bool
+
+    # NOTE : Field does not exist in schema
     @[JSON::Field(converter: Time::EpochConverter)]
     getter revoked_at : Time
   end

--- a/src/placeos/api/models/repository.cr
+++ b/src/placeos/api/models/repository.cr
@@ -4,6 +4,7 @@ module PlaceOS::Client::API::Models
   # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/repository.cr
   #
   struct Repository < Response
+    getter id : String
     getter name : String
     getter uri : String
     getter repo_type : String

--- a/src/placeos/api/models/repository.cr
+++ b/src/placeos/api/models/repository.cr
@@ -1,6 +1,27 @@
 require "./response"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/repository.cr
+  #
   struct Repository < Response
+    getter name : String
+    getter uri : String
+    getter repo_type : String
+    getter username : String
+    getter password : String
+    getter key : String
+    getter folder_name : String?
+    getter description : String?
+    getter commit_hash : String?
+    getter branch : String?
+    getter repo_type : Type?
+    getter username : String?
+    getter password : String?
+    getter key : String?
+  end
+
+  enum Type
+    Driver
+    Interface
   end
 end

--- a/src/placeos/api/models/settings.cr
+++ b/src/placeos/api/models/settings.cr
@@ -3,11 +3,21 @@ require "placeos-models/utilities/encryption"
 require "./response"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/settings.cr
+  #
   struct Settings < Response
     getter encryption_level : Encryption::Level
     getter settings_string : String = "{}"
     getter keys : Array(String) = [] of String
     getter settings_id : String? = nil
     getter parent_id : String
+    getter parent_type : ParentType
+  end
+
+  enum ParentType
+    ControlSystem
+    Driver
+    Module
+    Zone
   end
 end

--- a/src/placeos/api/models/settings.cr
+++ b/src/placeos/api/models/settings.cr
@@ -6,6 +6,7 @@ module PlaceOS::Client::API::Models
   # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/settings.cr
   #
   struct Settings < Response
+    # getter id : String
     getter encryption_level : Encryption::Level
     getter settings_string : String = "{}"
     getter keys : Array(String) = [] of String

--- a/src/placeos/api/models/trigger.cr
+++ b/src/placeos/api/models/trigger.cr
@@ -1,10 +1,11 @@
 require "./response"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/trigger.cr
+  #
   struct Trigger < Response
     getter name : String
     getter description : String
-    getter control_system_id : String
 
     getter actions : Actions
     getter conditions : Conditions
@@ -15,6 +16,8 @@ module PlaceOS::Client::API::Models
 
     getter enable_webhook : Bool
     getter supported_methods : Array(String)
+
+    getter control_system_id : String
 
     struct Actions < Response
       getter functions : Array(Function) = [] of PlaceOS::Client::API::Models::Trigger::Actions::Function

--- a/src/placeos/api/models/trigger.cr
+++ b/src/placeos/api/models/trigger.cr
@@ -4,6 +4,7 @@ module PlaceOS::Client::API::Models
   # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/trigger.cr
   #
   struct Trigger < Response
+    getter id : String
     getter name : String
     getter description : String
 

--- a/src/placeos/api/models/trigger_instance.cr
+++ b/src/placeos/api/models/trigger_instance.cr
@@ -4,6 +4,7 @@ module PlaceOS::Client::API::Models
   # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/trigger_instance.cr
   #
   struct TriggerInstance < Response
+    # getter id : String
     getter control_system_id : String? = nil
     getter trigger_id : String? = nil
     getter zone_id : String? = nil

--- a/src/placeos/api/models/trigger_instance.cr
+++ b/src/placeos/api/models/trigger_instance.cr
@@ -1,6 +1,8 @@
 require "./response"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/trigger_instance.cr
+  #
   struct TriggerInstance < Response
     getter control_system_id : String? = nil
     getter trigger_id : String? = nil

--- a/src/placeos/api/models/user.cr
+++ b/src/placeos/api/models/user.cr
@@ -1,31 +1,53 @@
 require "./response"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/user.cr
+  #
   # Metadata about the current user
   struct User < Response
     include Timestamps
 
+    # getter authority_id
+
     getter id : String
-    getter email_digest : String
-    getter nickname : String
+
     getter name : String
-    getter first_name : String
-    getter last_name : String
+    getter nickname : String
+
     getter country : String
-    getter building : String
     getter image : String
 
+    # getter misc : String?
+
+    getter first_name : String
+    getter last_name : String
+    getter building : String
+
+    # getter password_digest : String?
+    getter email_digest : String
+    # getter deleted : Bool
+    # getter access_token : String?
+    # getter refresh_token String?
+    # getter expires_at : Int64?
+    # getter password : String?
+
     # Admin only fields
-    getter sys_admin : Bool?
-    getter support : Bool?
     getter email : String?
     getter phone : String?
+
     getter ui_theme : String?
-    getter metadata : String?
+
     getter login_name : String?
     getter staff_id : String?
+
     getter card_number : String?
+
     getter groups : Array(String)?
+
+    getter sys_admin : Bool?
+    getter support : Bool?
+
+    getter metadata : String?
   end
 
   struct ResourceToken < Response

--- a/src/placeos/api/models/zone.cr
+++ b/src/placeos/api/models/zone.cr
@@ -2,6 +2,8 @@ require "./response"
 require "./trigger"
 
 module PlaceOS::Client::API::Models
+  # PlaceOS::Model GitHub Link: https://github.com/PlaceOS/models/blob/master/src/placeos-models/zone.cr
+  #
   struct Zone < Response
     include Timestamps
 
@@ -11,14 +13,17 @@ module PlaceOS::Client::API::Models
     # A human readable identifier.
     getter name : String
 
-    # A human readable identifier for displaying on interfaces
-    getter display_name : String?
+    # Markdown formatted text that describes the zone.
+    getter description : String?
+
+    # Space seperated list of tags for categorizing the zone.
+    getter tags : Array(String) = [] of String
 
     # Geo-location string (lat,long) or any other location
     getter location : String?
 
-    # Markdown formatted text that describes the zone.
-    getter description : String?
+    # A human readable identifier for displaying on interfaces
+    getter display_name : String?
 
     # Could be used as floor code or building code etc
     getter code : String?
@@ -35,8 +40,7 @@ module PlaceOS::Client::API::Models
     # Map identifier, could be a URL or id
     getter map_id : String?
 
-    # Space seperated list of tags for categorizing the zone.
-    getter tags : Array(String) = [] of String
+    # getter parent_id : String?
 
     # List of trigger ID's to be applied to all systems that associate with this zone.
     getter triggers : Array(String)

--- a/src/placeos/api_wrapper/auths/base.cr
+++ b/src/placeos/api_wrapper/auths/base.cr
@@ -31,12 +31,12 @@ module PlaceOS
       get base, params: from_args, as: Array(Model)
     end
 
-    def update(**args)
-      put "#{base}/#{id}", body: from_args, as: Model
-    end
-
     def create(**args) : Model
       post base, body: from_args, as: Model
+    end
+
+    def update(**args)
+      put "#{base}/#{id}", body: from_args, as: Model
     end
   end
 end

--- a/src/placeos/api_wrapper/cluster.cr
+++ b/src/placeos/api_wrapper/cluster.cr
@@ -2,6 +2,18 @@ require "./endpoint"
 
 module PlaceOS
   class Client::APIWrapper::Cluster < Client::APIWrapper::Endpoint
+    include Client::APIWrapper::Endpoint::Fetch(Cluster)
+    include Client::APIWrapper::Endpoint::Destroy
+
     getter base : String = "#{API_ROOT}/cluster"
+
+    # CRUD Actions
+    def search(
+      q : String? = nil,
+      limit : Int = 20,
+      offset : Int = 0
+    )
+      get base, params: from_args, as: Array(Cluster)
+    end
   end
 end

--- a/src/placeos/api_wrapper/domains.cr
+++ b/src/placeos/api_wrapper/domains.cr
@@ -6,5 +6,38 @@ module PlaceOS
     include Client::APIWrapper::Endpoint::Destroy
 
     getter base : String = "#{API_ROOT}/domains"
+
+    # CRUD Actions
+    def search(
+      q : String? = nil,
+      limit : Int = 20,
+      offset : Int = 0
+    )
+      get base, params: from_args, as: Array(Authority)
+    end
+
+    def create(
+      name : String,
+      domain : String,
+      description : String? = nil,
+      login_url : String = "/login?continue={{url}}",
+      logout_url : String = "/auth/logout",
+      internals : Hash(String, JSON::Any) = {} of String => JSON::Any,
+      config : Hash(String, JSON::Any) = {} of String => JSON::Anyy
+    )
+      post base, body: from_args, as: Authority
+    end
+
+    def update(
+      name : String?,
+      domain : String?,
+      description : String?,
+      login_url : String?,
+      logout_url : String?,
+      internals : Hash(String, JSON::Any)?,
+      config : Hash(String, JSON::Any)?
+    )
+      put "#{base}/#{id}", body: from_args, as: Authority
+    end
   end
 end

--- a/src/placeos/api_wrapper/domains.cr
+++ b/src/placeos/api_wrapper/domains.cr
@@ -19,11 +19,11 @@ module PlaceOS
     def create(
       name : String,
       domain : String,
-      description : String? = nil,
-      login_url : String = "/login?continue={{url}}",
-      logout_url : String = "/auth/logout",
-      internals : Hash(String, JSON::Any) = {} of String => JSON::Any,
-      config : Hash(String, JSON::Any) = {} of String => JSON::Anyy
+      description : String?,
+      login_url : String?,
+      logout_url : String?,
+      internals : Hash(String, JSON::Any)?,
+      config : Hash(String, JSON::Any)?
     )
       post base, body: from_args, as: Authority
     end

--- a/src/placeos/api_wrapper/drivers.cr
+++ b/src/placeos/api_wrapper/drivers.cr
@@ -59,11 +59,11 @@ module PlaceOS
 
     # Unique Actions
     def recompile(id : String)
-      post "#{base}/#{id}/recompile", as: Driver
+      post "#{base}/#{id}/recompile"
     end
 
     def compiled(id : String)
-      get "#{base}/#{id}/compiled", as: Driver
+      get "#{base}/#{id}/compiled"
     end
   end
 end

--- a/src/placeos/api_wrapper/drivers.cr
+++ b/src/placeos/api_wrapper/drivers.cr
@@ -34,25 +34,25 @@ module PlaceOS
       file_name : String,
       module_name : String,
       repository_id : String,
-      default_uri : String? = nil,
-      default_port : Int32? = nil,
-      description : String? = nil,
-      ignore_connected : Bool? = nil
+      default_uri : String?,
+      default_port : Int32?,
+      description : String?,
+      ignore_connected : Bool?
     )
       post base, body: from_args, as: Driver
     end
 
     def update(
       id : String,
-      name : String? = nil,
-      role : Role? = nil,
-      commit : String? = nil,
-      file_name : String? = nil,
-      module_name : String? = nil,
-      default_uri : String? = nil,
-      default_port : Int32? = nil,
-      description : String? = nil,
-      ignore_connected : Bool? = nil
+      name : String?,
+      role : Role?,
+      commit : String?,
+      file_name : String?,
+      module_name : String?,
+      default_uri : String?,
+      default_port : Int32?,
+      description : String?,
+      ignore_connected : Bool?
     )
       put "#{base}/#{id}", body: from_args, as: Driver
     end

--- a/src/placeos/api_wrapper/drivers.cr
+++ b/src/placeos/api_wrapper/drivers.cr
@@ -34,25 +34,25 @@ module PlaceOS
       file_name : String,
       module_name : String,
       repository_id : String,
-      default_uri : String?,
-      default_port : Int32?,
-      description : String?,
-      ignore_connected : Bool?
+      default_uri : String? = nil,
+      default_port : Int32? = nil,
+      description : String? = nil,
+      ignore_connected : Bool? = nil
     )
       post base, body: from_args, as: Driver
     end
 
     def update(
       id : String,
-      name : String?,
-      role : Role?,
-      commit : String?,
-      file_name : String?,
-      module_name : String?,
-      default_uri : String?,
-      default_port : Int32?,
-      description : String?,
-      ignore_connected : Bool?
+      name : String? = nil,
+      role : Role? = nil,
+      commit : String? = nil,
+      file_name : String? = nil,
+      module_name : String? = nil,
+      default_uri : String? = nil,
+      default_port : Int32? = nil,
+      description : String? = nil,
+      ignore_connected : Bool? = nil
     )
       put "#{base}/#{id}", body: from_args, as: Driver
     end

--- a/src/placeos/api_wrapper/drivers.cr
+++ b/src/placeos/api_wrapper/drivers.cr
@@ -56,5 +56,14 @@ module PlaceOS
     )
       put "#{base}/#{id}", body: from_args, as: Driver
     end
+
+    # Unique Actions
+    def recompile(id : String)
+      post "#{base}/#{id}/recompile", as: Driver
+    end
+
+    def compiled(id : String)
+      get "#{base}/#{id}/compiled", as: Driver
+    end
   end
 end

--- a/src/placeos/api_wrapper/endpoint.cr
+++ b/src/placeos/api_wrapper/endpoint.cr
@@ -11,11 +11,20 @@ module PlaceOS
     def initialize(@client : APIWrapper)
     end
 
+    module Search(T)
+    end
+
     module Fetch(T)
       # Returns a {{ T.id }}
       def fetch(id : String)
         get "#{base}/#{id}", as: T
       end
+    end
+
+    module Create(T)
+    end
+
+    module Update(T)
     end
 
     module Destroy

--- a/src/placeos/api_wrapper/modules.cr
+++ b/src/placeos/api_wrapper/modules.cr
@@ -109,5 +109,23 @@ module PlaceOS
     )
       put "#{base}/#{id}", body: from_args, as: API::Models::Module
     end
+
+    # Unique Actions
+    def settings(id : String)
+      get "#{base}/#{id}/settings"
+    end
+
+    # Current
+    def execute(
+      id : String,
+      method : String,
+      *args : Array(JSON::Any::Type)
+    )
+      post "#{base}/#{id}/exec/#{method}", body: args
+    end
+
+    def load(id : String)
+      post "#{base}/#{id}/load"
+    end
   end
 end

--- a/src/placeos/api_wrapper/modules.cr
+++ b/src/placeos/api_wrapper/modules.cr
@@ -68,7 +68,7 @@ module PlaceOS
       control_system_id : String? = nil,
       driver_id : String? = nil
     )
-      get base, params: from_args, as: Array(API::Models::Module)
+      get base, params: from_args, as: Array(Module)
     end
 
     # Management
@@ -89,7 +89,7 @@ module PlaceOS
       ignore_connected : Bool? = nil,
       ignore_startstop : Bool? = nil
     )
-      post base, body: from_args, as: API::Models::Module
+      post base, body: from_args, as: Module
     end
 
     # Updates module attributes or configuration.
@@ -107,7 +107,7 @@ module PlaceOS
       ignore_connected : Bool? = nil,
       ignore_startstop : Bool? = nil
     )
-      put "#{base}/#{id}", body: from_args, as: API::Models::Module
+      put "#{base}/#{id}", body: from_args, as: Module
     end
 
     # Unique Actions

--- a/src/placeos/api_wrapper/oauth_applications.cr
+++ b/src/placeos/api_wrapper/oauth_applications.cr
@@ -32,6 +32,20 @@ module PlaceOS
       get base, params: from_args, as: Array(OAuthApplication)
     end
 
+    def create(
+      name : String,
+      uid : String? = nil,
+      secret : String? = nil,
+      scopes : String? = nil,
+      owner_id : String? = nil,
+      redirect_uri : String? = nil,
+      skip_authorization : Bool? = nil,
+      confidential : Bool? = nil,
+      revoked_at : Time? = nil
+    )
+      post base, body: from_args, as: OAuthApplication
+    end
+
     def update(
       id : String,
       name : String? = nil,
@@ -45,20 +59,6 @@ module PlaceOS
       revoked_at : Time? = nil
     )
       put "#{base}/#{id}", body: from_args, as: OAuthApplication
-    end
-
-    def create(
-      name : String,
-      uid : String? = nil,
-      secret : String? = nil,
-      scopes : String? = nil,
-      owner_id : String? = nil,
-      redirect_uri : String? = nil,
-      skip_authorization : Bool? = nil,
-      confidential : Bool? = nil,
-      revoked_at : Time? = nil
-    )
-      post base, body: from_args, as: OAuthApplication
     end
   end
 end

--- a/src/placeos/api_wrapper/repositories.cr
+++ b/src/placeos/api_wrapper/repositories.cr
@@ -46,9 +46,9 @@ module PlaceOS
       username : String,
       password : String,
       key : String,
-      folder_name : String? = nil,
-      description : String? = nil,
-      commit_hash : String = "HEAD"
+      folder_name : String?,
+      description : String?,
+      commit_hash : String?
     )
       post base, body: from_args, as: Repository
     end
@@ -62,7 +62,7 @@ module PlaceOS
       key : String,
       folder_name : String?,
       description : String?,
-      commit_hash : String = "HEAD"
+      commit_hash : String?
     )
       put "#{base}/#{id}", body: from_args, as: Repository
     end

--- a/src/placeos/api_wrapper/repositories.cr
+++ b/src/placeos/api_wrapper/repositories.cr
@@ -81,11 +81,11 @@ module PlaceOS
     end
 
     def commits(id : String, count : Int32?, driver : String?)
-      get "#{base}/#{id}/commits", body: from_args
+      get "#{base}/#{id}/commits", params: from_args
     end
 
     def details(id : String, driver : String, commit : String)
-      get "#{base}/#{id}/details", body: from_args
+      get "#{base}/#{id}/details", params: from_args
     end
 
     def branches(id : String)

--- a/src/placeos/api_wrapper/repositories.cr
+++ b/src/placeos/api_wrapper/repositories.cr
@@ -6,5 +6,90 @@ module PlaceOS
     include Client::APIWrapper::Endpoint::Destroy
 
     getter base : String = "#{API_ROOT}/repositories"
+
+    # CRUD Actions
+    # Search
+    ###########################################################################
+
+    # List or search for modules.
+    #
+    # Results maybe filtered by specifying a query - *q* - to search across module
+    # attributes. A small query language is supported within this:
+    #
+    # Operator | Action
+    # -------- | ------
+    # `+`      | Matches both terms
+    # `|`      | Matches either terms
+    # `-`      | Negates a single token
+    # `"`      | Wraps tokens to form a phrase
+    # `(`  `)` | Provides precedence
+    # `~N`     | Specifies edit distance (fuzziness) after a word
+    # `~N`     | Specifies slop amount (deviation) after a phrase
+    #
+    # Up to *limit* systems will be returned, with a paging based on *offset*.
+    #
+    # Results my also also be limited to those associated with a specific
+    # *system_id*, that are instances of a *driver_id*, or any combination of
+    # these.
+    def search(
+      q : String? = nil,
+      limit : Int = 20,
+      offset : Int = 0
+    )
+      get base, params: from_args, as: Array(Repository)
+    end
+
+    def create(
+      name : String,
+      uri : String,
+      repo_type : String,
+      username : String,
+      password : String,
+      key : String,
+      folder_name : String? = nil,
+      description : String? = nil,
+      commit_hash : String = "HEAD"
+    )
+      post base, body: from_args, as: Repository
+    end
+
+    def update(
+      name : String?,
+      uri : String?,
+      repo_type : String?,
+      username : String,
+      password : String,
+      key : String,
+      folder_name : String?,
+      description : String?,
+      commit_hash : String = "HEAD"
+    )
+      put "#{base}/#{id}", body: from_args, as: Repository
+    end
+
+    # Unique Actions
+    def pull(id : String)
+      post "#{base}/#{id}/pull"
+    end
+
+    def loaded_interfaces
+      get "#{base}/interfaces"
+    end
+
+    def drivers(id : String)
+      get "#{base}/#{id}/drivers"
+    end
+
+    def commits(id : String, count : Int32?, driver : String?)
+      get "#{base}/#{id}/commits", body: from_args
+    end
+
+    def details(id : String, driver : String, commit : String)
+      get "#{base}/#{id}/details", body: from_args
+    end
+
+    def branches(id : String)
+      get "#{base}/#{id}/branches"
+    end
   end
 end

--- a/src/placeos/api_wrapper/root.cr
+++ b/src/placeos/api_wrapper/root.cr
@@ -15,5 +15,18 @@ module PlaceOS
     def version
       get "#{base}/version", as: API::Models::Version
     end
+
+    # Unique Actions
+    def root
+      get "#{base}"
+    end
+
+    def reindex(backfill : Bool?)
+      get "#{base}/reindex", params: from_args
+    end
+
+    def backfill
+      get "#{base}/backfill"
+    end
   end
 end

--- a/src/placeos/api_wrapper/settings.cr
+++ b/src/placeos/api_wrapper/settings.cr
@@ -6,5 +6,43 @@ module PlaceOS
     include Client::APIWrapper::Endpoint::Destroy
 
     getter base : String = "#{API_ROOT}/settings"
+
+    # CRUD Actions
+    def search(
+      parent_id : String?,
+      q : String? = nil,
+      limit : Int = 20,
+      offset : Int = 0
+    )
+      get base, params: from_args, as: Array(API::Models::Settings)
+    end
+
+    def create(
+      parent_id : String,
+      encryption_level : String,
+      parent_type : String,
+      settings_string : String = "{}",
+      settings_id : String? = nil,
+      keys : Array(String) = [] of String
+    )
+      post base, body: from_args, as: API::Models::Settings
+    end
+
+    def update(
+      id : String,
+      parent_id : String,
+      encryption_level : String?,
+      parent_type : String?,
+      settings_string : String?,
+      settings_id : String?,
+      keys : Array(String)?
+    )
+      put "#{base}/#{id}", body: from_args, as: API::Models::Settings
+    end
+
+    # Unique Actions
+    def history(id : String, offset : Int32?, limit : Int32?)
+      get "#{base}/#{id}/history", params: from_args
+    end
   end
 end

--- a/src/placeos/api_wrapper/system_triggers.cr
+++ b/src/placeos/api_wrapper/system_triggers.cr
@@ -2,7 +2,54 @@ require "./endpoint"
 
 module PlaceOS
   class Client::APIWrapper::SystemTriggers < Client::APIWrapper::Endpoint
+    include Client::APIWrapper::Endpoint::Destroy
+
     # SystemTriggers are embedded beneath a systems route
     getter base : String = "#{API_ROOT}/systems"
+
+    # CRUD Actions
+    def search(
+      control_system_id : String?,
+      trigger_id : String?,
+      zone_id : String?,
+      q : String? = nil,
+      limit : Int = 20,
+      offset : Int = 0
+    )
+      get base, params: from_args, as: Array(API::Models::TriggerInstance)
+    end
+
+    def fetch(id : String, complete : Bool?)
+      get "#{base}/#{id}", params: from_args, as: API::Model::TriggerInstance
+    end
+
+    def create(
+      control_system_id : String,
+      trigger_id : String,
+      zone_id : String,
+      enabled : Bool?,
+      triggered : Bool?,
+      important : Bool?,
+      exec_enabled : Bool?,
+      webhook_secret : String?,
+      trigger_count : Int32?
+    )
+      post base, body: from_args, as: API::Models::TriggerInstance
+    end
+
+    def update(
+      id : String,
+      control_system_id : String?,
+      trigger_id : String?,
+      zone_id : String?,
+      enabled : Bool?,
+      triggered : Bool?,
+      important : Bool?,
+      exec_enabled : Bool?,
+      webhook_secret : String?,
+      trigger_count : Int32?
+    )
+      post "#{base}/#{id}", body: from_args, as: API::Models::TriggerInstance
+    end
   end
 end

--- a/src/placeos/api_wrapper/systems.cr
+++ b/src/placeos/api_wrapper/systems.cr
@@ -142,6 +142,27 @@ module PlaceOS
       get "#{base}/with_emails", params: HTTP::Params{"in" => query}, as: Array(System)
     end
 
+    # Unique Actions
+    def zones(id : String)
+      get "#{base}/#{id}/zones"
+    end
+
+    def settings(id : String)
+      get "#{base}/#{id}/settings"
+    end
+
+    def add_module(id : String, module_id : String)
+      put "#{base}/#{id}/module/#{module_id}"
+    end
+
+    def remove_module(id : String, module_id : String)
+      delete "#{base}/#{id}/module/#{module_id}"
+    end
+
+    def control
+      ws "#{base}/control"
+    end
+
     private getter client
 
     def initialize(@client : APIWrapper)

--- a/src/placeos/api_wrapper/triggers.cr
+++ b/src/placeos/api_wrapper/triggers.cr
@@ -6,5 +6,49 @@ module PlaceOS
     include Client::APIWrapper::Endpoint::Destroy
 
     getter base : String = "#{API_ROOT}/triggers"
+
+    # CRUD Actions
+    def search(
+      authority_id : String?,
+      q : String? = nil,
+      limit : Int = 20,
+      offset : Int = 0
+    )
+      get base, params: from_args, as: Array(Trigger)
+    end
+
+    def create(
+      control_system_id : String,
+      name : String,
+      description : String?,
+      actions : String?,
+      conditions : String?,
+      debounce_period : Int32?,
+      important : Bool?,
+      enable_webhook : Bool?,
+      supported_methods : Array(String)?
+    )
+      post base, body: from_args, as: Trigger
+    end
+
+    def update(
+      id : String,
+      control_system_id : String,
+      name : String,
+      description : String?,
+      actions : String?,
+      conditions : String?,
+      debounce_period : Int32?,
+      important : Bool?,
+      enable_webhook : Bool?,
+      supported_methods : Array(String)?
+    )
+      put "#{base}/#{id}", body: from_args, as: Trigger
+    end
+
+    # Unique Actions
+    def instances(id : String)
+      get "#{base}/#{id}/instance", as: Array(Trigger)
+    end
   end
 end

--- a/src/placeos/api_wrapper/triggers.cr
+++ b/src/placeos/api_wrapper/triggers.cr
@@ -48,7 +48,7 @@ module PlaceOS
 
     # Unique Actions
     def instances(id : String)
-      get "#{base}/#{id}/instance", as: Array(Trigger)
+      get "#{base}/#{id}/instance"
     end
   end
 end

--- a/src/placeos/api_wrapper/users.cr
+++ b/src/placeos/api_wrapper/users.cr
@@ -18,5 +18,77 @@ module PlaceOS
     def resource_token
       post "#{base}/resource_token", as: ResourceToken
     end
+
+    # CRUD Actions
+    def search(
+      q : String? = nil,
+      limit : Int = 20,
+      offset : Int = 0
+    )
+      get base, params: from_args, as: Array(User)
+    end
+
+    def create(
+      authority_id : String,
+      name : String,
+      nickname : String?,
+      email : String?,
+      phone : String?,
+      country : String?,
+      image : String?,
+      ui_theme : String?,
+      metadata : String?,
+      login_name : String?,
+      staff_id : String?,
+      first_name : String?,
+      last_name : String?,
+      building : String?,
+      password_digest : String?,
+      email_digest : String?,
+      card_number : String?,
+      deleted : Bool?,
+      groups : Array(String)?,
+      access_token : String?,
+      refresh_token : String?,
+      expires_at : Int64?,
+      expires : Bool?,
+      password : String?,
+      sys_admin : Bool?,
+      support : Bool?
+    )
+      post base, body: from_args, as: User
+    end
+
+    def update(
+      id : String,
+      authority_id : String,
+      name : String,
+      nickname : String?,
+      email : String?,
+      phone : String?,
+      country : String?,
+      image : String?,
+      ui_theme : String?,
+      metadata : String?,
+      login_name : String?,
+      staff_id : String?,
+      first_name : String?,
+      last_name : String?,
+      building : String?,
+      password_digest : String?,
+      email_digest : String?,
+      card_number : String?,
+      deleted : Bool?,
+      groups : Array(String)?,
+      access_token : String?,
+      refresh_token : String?,
+      expires_at : Int64?,
+      expires : Bool?,
+      password : String?,
+      sys_admin : Bool?,
+      support : Bool?
+    )
+      put "#{base}/#{id}", body: from_args, as: User
+    end
   end
 end

--- a/src/placeos/api_wrapper/users.cr
+++ b/src/placeos/api_wrapper/users.cr
@@ -11,14 +11,6 @@ module PlaceOS
 
     getter base : String = "#{API_ROOT}/users"
 
-    def current
-      get "#{base}/current", as: User
-    end
-
-    def resource_token
-      post "#{base}/resource_token", as: ResourceToken
-    end
-
     # CRUD Actions
     def search(
       q : String? = nil,
@@ -89,6 +81,14 @@ module PlaceOS
       support : Bool?
     )
       put "#{base}/#{id}", body: from_args, as: User
+    end
+
+    def current
+      get "#{base}/current", as: User
+    end
+
+    def resource_token
+      post "#{base}/resource_token", as: ResourceToken
     end
   end
 end

--- a/src/placeos/api_wrapper/webhook.cr
+++ b/src/placeos/api_wrapper/webhook.cr
@@ -1,6 +1,6 @@
 require "./endpoint"
 
 module PlaceOS
-  class Client::APIWrapper::Webhook < Client::APIWrapper::Endpoint
+  class Client::APIWrapper::Webhook
   end
 end

--- a/src/placeos/api_wrapper/webhook.cr
+++ b/src/placeos/api_wrapper/webhook.cr
@@ -1,0 +1,6 @@
+require "./endpoint"
+
+module PlaceOS
+  class Client::APIWrapper::Webhook < Client::APIWrapper::Endpoint
+  end
+end

--- a/src/placeos/api_wrapper/zones.cr
+++ b/src/placeos/api_wrapper/zones.cr
@@ -78,6 +78,11 @@ module PlaceOS
       get base, params: from_args, as: Array(API::Models::Zone)
     end
 
+    # Unique Actions
+    def trigger(id : String)
+      get "#{base}/#{id}/triggers"
+    end
+
     private getter client
 
     def initialize(@client : APIWrapper)

--- a/src/placeos/api_wrapper/zones.cr
+++ b/src/placeos/api_wrapper/zones.cr
@@ -32,7 +32,7 @@ module PlaceOS
       settings : Settings? = nil,
       triggers : Array(String)? = nil
     )
-      post base, body: from_args, as: API::Models::Zone
+      post base, body: from_args, as: API::Models::Zone # Should this just be Zone
     end
 
     # Updates zone attributes or configuration.


### PR DESCRIPTION
- The purpose of this PR is to expand crystal-client to cover all existing `rest-api` routes and controller actions, accompanied by specs, as a lot of methods in `crystal-client` are missing to write further specs in `release` integration tests.

- There are a few questions I would like to ask:

1. There seems to be a repeated pattern of assigning default values to client models that correspond to those of `PlaceOS::Model`. However, I see this as unnecessary, since client models are mostly if not only used to parse response objects, and never initialised on its own, hence it should receive all the fields directly from `PlaceOS::Model`. Secondly, there seems to be a pattern of assigning default values to `crystal-client` methods that make call to `rest-api`, however, for most these fields, `rest-api` has specified a default value if they were left `nil`, therefore, specifying default values in these methods seem to be redundant. Should I remove these?

2. I have not used `elastic` before, and I see it being repeatedly used in `rest-api`'s `index` with the following pattern

```
      elastic = Model::{{name}}.elastic
      query = elastic.query(params)

      # further query adjustment here

      results = paginate_results(elastic, query)
      render json: results
```

How exactly does the `#elastic` method work? I couldn't find any docs for this inside of `rest-api` itself. I need to know this as I need to add missing `#search` methods with specific params that I am not aware of in `crystal-client`