### PR TITLE
feat: allow custom host headers to be defined

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos
-version: 2.3.0
+version: 2.4.0
 crystal: ~> 1.0
 license: MIT
 

--- a/src/placeos/api_wrapper.cr
+++ b/src/placeos/api_wrapper.cr
@@ -20,18 +20,19 @@ module PlaceOS
 
     protected getter authenticate : HTTP::Client -> = ->(_client : HTTP::Client) {}
     protected getter uri : URI
+    protected getter host_header : String?
 
     # TODO:
     # before_request
     # connect_timeout=
     # read_timeout=
 
-    def initialize(uri : URI | String, &authenticate : HTTP::Client ->)
+    def initialize(uri : URI | String, @host_header : String? = nil, &authenticate : HTTP::Client ->)
       @uri = uri.is_a?(String) ? URI.parse(uri) : uri
       @authenticate = authenticate
     end
 
-    def initialize(uri : URI | String)
+    def initialize(uri : URI | String, @host_header : String? = nil)
       @uri = uri.is_a?(String) ? URI.parse(uri) : uri
     end
 

--- a/src/placeos/api_wrapper/endpoint.cr
+++ b/src/placeos/api_wrapper/endpoint.cr
@@ -88,6 +88,11 @@ module PlaceOS
         {% end %}
       {% end %}
 
+      if client.host_header
+        headers ||= HTTP::Headers.new
+        headers["Host"] = client.host_header
+      end
+
       # Exec the request
       response = client.connection &.{{method.id}}(path, headers, body)
       raise API::Error.from_response(response) unless response.success?

--- a/src/placeos/api_wrapper/endpoint.cr
+++ b/src/placeos/api_wrapper/endpoint.cr
@@ -88,9 +88,9 @@ module PlaceOS
         {% end %}
       {% end %}
 
-      if client.host_header
+      if host_header = client.host_header.presence
         headers ||= HTTP::Headers.new
-        headers["Host"] = client.host_header
+        headers["Host"] = host_header
       end
 
       # Exec the request

--- a/src/placeos/client.cr
+++ b/src/placeos/client.cr
@@ -43,10 +43,11 @@ module PlaceOS
       @client_id : String? = nil,
       @client_secret : String? = nil,
       # Allow for a token to be used directly (proxying auth)
-      @token : OAuth2::AccessToken? = nil
+      @token : OAuth2::AccessToken? = nil,
+      @host_header : String? = nil
     )
       @uri = base_uri.is_a?(String) ? URI.parse(base_uri) : base_uri
-      @api_wrapper = APIWrapper.new(@uri) do |http|
+      @api_wrapper = APIWrapper.new(@uri, @host_header) do |http|
         authenticate(http)
       end
     end


### PR DESCRIPTION
useful when we have multi-tenancy, a single staff API talking to a single PlaceOS
but credentials that apply to different domains
so we use the host header to define the domain but actual comms occur over an internal local link