### PR TITLE
feat: user search

### DIFF
--- a/spec/placeos/api_wrapper/users_spec.cr
+++ b/spec/placeos/api_wrapper/users_spec.cr
@@ -1,0 +1,33 @@
+require "../../spec_helper"
+
+module PlaceOS
+  describe Client::APIWrapper::Users do
+    api = Client::APIWrapper.new DOMAIN
+    client = Client::APIWrapper::Users.new api
+
+    users_json = <<-JSON
+    [
+      {
+        "id": "user-wJHShR4Ffa",
+        "email": "john@example.com",
+        "email_digest": "---",
+        "name": "John Doe",
+        "created_at": 1555995992,
+        "updated_at": 1555996000
+      }
+    ]
+    JSON
+
+    describe "#search" do
+      it "provides user search" do
+        WebMock
+          .stub(:get, DOMAIN + client.base)
+          .with(query: {"q" => "\"John Doe\"", "limit" => "20", "offset" => "0"})
+          .to_return(body: users_json)
+        result = client.search "\"John Doe\""
+        result.size.should eq(1)
+        result.first.email.should eq("john@example.com")
+      end
+    end
+  end
+end

--- a/src/placeos/api_wrapper/users.cr
+++ b/src/placeos/api_wrapper/users.cr
@@ -2,7 +2,6 @@ require "./endpoint"
 
 module PlaceOS
   # TODO:
-  # - search (index)
   # - create
   # - update
   class Client::APIWrapper::Users < Client::APIWrapper::Endpoint
@@ -17,6 +16,33 @@ module PlaceOS
 
     def resource_token
       post "#{base}/resource_token", as: ResourceToken
+    end
+
+    # List or search for users.
+    #
+    # Results maybe filtered by specifying a query - *q* - to search across zone
+    # attributes. A small query language is supported within this:
+    #
+    # Operator | Action
+    # -------- | ------
+    # `+`      | Matches both terms
+    # `|`      | Matches either terms
+    # `-`      | Negates a single token
+    # `"`      | Wraps tokens to form a phrase
+    # `(`  `)` | Provides precedence
+    # `~N`     | Specifies edit distance (fuzziness) after a word
+    # `~N`     | Specifies slop amount (deviation) after a phrase
+    #
+    # Up to *limit* zones will be returned, with a paging based on *offset*.
+    #
+    # Results my also also be limited to those associated with specific *tags*.
+    def search(
+      q : String? = nil,
+      limit : Int = 20,
+      offset : Int = 0,
+      authority_id : String? = nil
+    )
+      get base, params: from_args, as: Array(API::Models::User)
     end
   end
 end


### PR DESCRIPTION
Implements support for `client.users.search` to pair with functionality exposed via the [`Users#index`](https://github.com/PlaceOS/rest-api/blob/5d3acc0cff8d949d360a8f6de9c2e916c52f5cf1/src/placeos-rest-api/controllers/users.cr#L92-L102) endpoint.

Closes #19.

