### PR TITLE
feat: get_access_token_using_resource_owner_credentials insecure

### DIFF
--- a/src/placeos/client.cr
+++ b/src/placeos/client.cr
@@ -98,6 +98,12 @@ module PlaceOS
         token_uri: TOKEN_ENDPOINT,
       )
 
+      if @insecure && (uri.scheme.try(&.downcase) || "https") == "https"
+        tls = OpenSSL::SSL::Context::Client.new
+        tls.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+        client.http_client = HTTP::Client.new(uri.host.as(String), uri.port, tls)
+      end
+
       token = client.get_access_token_using_resource_owner_credentials(
         @email.as(String),
         @password.as(String),


### PR DESCRIPTION
I don't think this is possible on crystal 1.0