### PR TITLE
add parent_id to zone model

### DIFF
--- a/src/placeos/api/models/zone.cr
+++ b/src/placeos/api/models/zone.cr
@@ -42,7 +42,7 @@ module PlaceOS::Client::API::Models
     getter triggers : Array(String)
 
     # Parent id
-    getter parent_id : String
+    getter parent_id : String?
 
     # Trigger data returned when param `complete` is `true`
     getter trigger_data : Array(Trigger)?

--- a/src/placeos/api/models/zone.cr
+++ b/src/placeos/api/models/zone.cr
@@ -41,6 +41,9 @@ module PlaceOS::Client::API::Models
     # List of trigger ID's to be applied to all systems that associate with this zone.
     getter triggers : Array(String)
 
+    # Parent id
+    getter parent_id : String
+
     # Trigger data returned when param `complete` is `true`
     getter trigger_data : Array(Trigger)?
   end


### PR DESCRIPTION
Hi guys,

staff_api.zone/zones is missing parent_id, this PR adds it.
Please let us know when you update the drivers.

Thanks