### PR TITLE
feat: add `merge` for  `Metadata`

### DIFF
--- a/spec/placeos/api_wrapper/metadata_spec.cr
+++ b/spec/placeos/api_wrapper/metadata_spec.cr
@@ -65,6 +65,14 @@ module PlaceOS
       client.update("zone-oOj2lGgsz", "Place1", {name: "frodo"}, "metadata 1").should eq Client::API::Models::Metadata.from_json(mock_metadata["Place1"])
     end
 
+    it "merge" do
+      WebMock
+        .stub(:patch, DOMAIN + "#{client.base}/zone-oOj2lGgsz")
+        .with(query: {"name" => "Place1"}, body: mock_metadata["Place1"])
+        .to_return(status: 200, body: mock_metadata["Place1"])
+      client.merge("zone-oOj2lGgsz", "Place1", {name: "frodo"}, "metadata 1").should eq Client::API::Models::Metadata.from_json(mock_metadata["Place1"])
+    end
+
     it "delete" do
       WebMock
         .stub(:delete, DOMAIN + "#{client.base}/zone-oOj2lGgsz")

--- a/src/placeos/api_wrapper/metadata.cr
+++ b/src/placeos/api_wrapper/metadata.cr
@@ -24,6 +24,17 @@ module PlaceOS
       put "#{base}/#{id}?#{params}", body: body, as: API::Models::Metadata
     end
 
+    def merge(
+      id : String,
+      name : String,
+      details : JSON::Any | Hash | NamedTuple | Array,
+      description : String? = nil
+    )
+      params = HTTP::Params{"name" => name}
+      body = {name: name, description: description, details: details, parent_id: id}
+      patch "#{base}/#{id}?#{params}", body: body, as: API::Models::Metadata
+    end
+
     def destroy(id : String, name : String)
       delete "#{base}/#{id}", params: from_args
       nil


### PR DESCRIPTION
Adding method merge for metadata. Already a put method has been implemented but patch is missing.

<!-- Describe the scope of your change - i.e. what the change does. -->

required to update metadata via merge behaviour:
https://github.com/PlaceOS/rest-api/blob/master/src/placeos-rest-api/controllers/metadata.cr#L133

<!-- What benefits will be realized by the code change? -->

