### PR TITLE
Add timeout to driver recompile

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos
-version: 2.12.1
+version: 2.12.2
 license: MIT
 
 description: |

--- a/src/placeos/api_wrapper/drivers.cr
+++ b/src/placeos/api_wrapper/drivers.cr
@@ -57,8 +57,9 @@ module PlaceOS
       put "#{base}/#{id}", body: from_args, as: Driver
     end
 
-    def recompile(id : String)
+    def recompile(id : String, timeout : Time::Span = 10.minutes)
       client.connection do |conn|
+        conn.read_timeout = timeout
         url = "#{base}/#{id}/recompile"
         response = conn.post(url)
         unless response.success?


### PR DESCRIPTION
Adds a configurable timeout to the driver recompile request. 10 minute default
Bumps shard version